### PR TITLE
Checkpoint update

### DIFF
--- a/gmtk-jam-2025/Characters/Daniel/daniel_running.gd
+++ b/gmtk-jam-2025/Characters/Daniel/daniel_running.gd
@@ -47,6 +47,7 @@ var in_air : bool = true
 var jumping:bool = false
 var is_paused : bool = false
 
+var last_checkpoint : int = 0
 
 func _physics_process(delta: float) -> void:
 	handle_basics(delta)

--- a/gmtk-jam-2025/Levels/Scripts/check_point.gd
+++ b/gmtk-jam-2025/Levels/Scripts/check_point.gd
@@ -1,19 +1,24 @@
 class_name Checkpoint extends Area3D
 
-static var checkpoint_count = 5
+static var checkpoint_count = 3
 @export var checkpoint_id : int = 0
 
 func _on_body_entered(body: Node3D) -> void:
 	if body is BasicPlayer and checkpoint_valid(body):
-		set_respawn(body)
+		
+		set_checkpoint(body)
 		play_sound(body)
+	else:
+		print("Entered wrong checkpoint OR not player")
 
-func set_respawn(player : BasicPlayer) -> void:
+func set_checkpoint(player : BasicPlayer) -> void:
 	player.respawn_point = global_transform
+	player.last_checkpoint = checkpoint_id
 
 func play_sound(player : BasicPlayer) -> void:
 	if player.windspeed < -5: $Collect.play()
 	else: $VibeCollect.play()
 
 func checkpoint_valid(player : BasicPlayer) -> bool:
-	return player.last_checkpoint == (checkpoint_id - 1) % checkpoint_count
+	print((player.last_checkpoint + 1) % checkpoint_count)
+	return (player.last_checkpoint + 1) % checkpoint_count == checkpoint_id

--- a/gmtk-jam-2025/Levels/Scripts/check_point.gd
+++ b/gmtk-jam-2025/Levels/Scripts/check_point.gd
@@ -1,13 +1,19 @@
-extends Area3D
+class_name Checkpoint extends Area3D
 
-var entered_checkpoint = []
+static var checkpoint_count = 5
+@export var checkpoint_id : int = 0
 
 func _on_body_entered(body: Node3D) -> void:
-	if body.is_in_group("player"):
-		body.respawn_point = global_transform
-		if entered_checkpoint.find(body.player_id)==-1:
-			entered_checkpoint.append(body.player_id)
-			if body.windspeed < -5:
-				$Collect.play()
-			else:
-				$VibeCollect.play()
+	if body is BasicPlayer and checkpoint_valid(body):
+		set_respawn(body)
+		play_sound(body)
+
+func set_respawn(player : BasicPlayer) -> void:
+	player.respawn_point = global_transform
+
+func play_sound(player : BasicPlayer) -> void:
+	if player.windspeed < -5: $Collect.play()
+	else: $VibeCollect.play()
+
+func checkpoint_valid(player : BasicPlayer) -> bool:
+	return player.last_checkpoint == (checkpoint_id - 1) % checkpoint_count

--- a/gmtk-jam-2025/Levels/Scripts/goal_post.gd
+++ b/gmtk-jam-2025/Levels/Scripts/goal_post.gd
@@ -2,11 +2,17 @@ class_name Goalpost extends Checkpoint
 
 func _on_body_entered(body: Node3D) -> void:
 	if body is BasicPlayer and checkpoint_valid(body):
-		set_respawn(body)
+		set_checkpoint(body)
 		increase_speed(body)
 		play_sound(body)
 		reset_timer(body)
 		reset_items(body)
+	else:
+		print("Entered wrong checkpoint OR not player")
+
+func play_sound(player : BasicPlayer) -> void:
+	if player.windspeed < -5: $Horn.play()
+	else: $Vibe.play()
 
 func reset_timer(player : BasicPlayer):
 	if player.timer:

--- a/gmtk-jam-2025/Levels/Scripts/goal_post.gd
+++ b/gmtk-jam-2025/Levels/Scripts/goal_post.gd
@@ -1,35 +1,30 @@
-extends Area3D
+class_name Goalpost extends Checkpoint
 
-var list = []
 func _on_body_entered(body: Node3D) -> void:
-	if body.is_in_group("player"):
-		body.respawn_point = global_transform
-		var successful_lap = true
-		for i in get_children():
-			if i is Area3D:
-				if i.entered_checkpoint.find(body.player_id)!=-1:
-					i.entered_checkpoint.erase(body.player_id)
-					continue
-				else:
-					successful_lap = false
-					break
-		if successful_lap:
-			body.starting_speed = body.default_speed + 1.25
-			body.starting_top_speed = body.top_speed + 1.5
-			body.default_speed += 2.5
-			body.top_speed += 3
-			if body.windspeed < -5:
-				$Horn.play()
-			else:
-				$Vibe.play()
-			if body.timer:
-				body.timer.cross_goal_post()
-				body.lap_counter.increment()
-			for i in get_tree().get_nodes_in_group("stopwatch"):
-				if i.player_id == body.player_id:
-					i.reset()
-					break
-			for i in get_tree().get_nodes_in_group("speedbuff"):
-				if i.player_id == body.player_id:
-					i.reset()
-					break
+	if body is BasicPlayer and checkpoint_valid(body):
+		set_respawn(body)
+		increase_speed(body)
+		play_sound(body)
+		reset_timer(body)
+		reset_items(body)
+
+func reset_timer(player : BasicPlayer):
+	if player.timer:
+		player.timer.cross_goal_post()
+		player.lap_counter.increment()
+
+func reset_items(player : BasicPlayer):
+	for i in get_tree().get_nodes_in_group("stopwatch"):
+		if i.player_id == player.player_id:
+			i.reset()
+			break
+	for i in get_tree().get_nodes_in_group("speedbuff"):
+		if i.player_id == player.player_id:
+			i.reset()
+			break
+
+func increase_speed(player : BasicPlayer):
+	player.starting_speed = player.default_speed + 1.25
+	player.starting_top_speed = player.top_speed + 1.5
+	player.default_speed += 2.5
+	player.top_speed += 3

--- a/gmtk-jam-2025/Levels/test_room.tscn
+++ b/gmtk-jam-2025/Levels/test_room.tscn
@@ -372,9 +372,11 @@ mesh = SubResource("SphereMesh_3k1a2")
 
 [node name="CheckPoint" parent="GoalPost" unique_id=60854152 instance=ExtResource("4_3k1a2")]
 transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 329, -18, 63)
+checkpoint_id = 1
 
 [node name="CheckPoint2" parent="GoalPost" unique_id=853819525 instance=ExtResource("4_3k1a2")]
 transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 111, -41, 258)
+checkpoint_id = 2
 
 [node name="Horn" type="AudioStreamPlayer" parent="GoalPost" unique_id=1821089489]
 stream = ExtResource("6_v4rkh")


### PR DESCRIPTION
Checkpoints are now ordered.
To add multiple checkpoints, change the static var for checkpoint count in the checkpoint class.
The checkpoint ID is used to make sure the player enters them in the correct order.
Multiple checkpoints can have the same ID if you want to provide players multiple options for a single section of track.
The goalpost has been modified to be a fancy checkpoint, and it should use the ID of 0.